### PR TITLE
0.0.8 merge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ version = "^0.3.0"
 optional = true
 
 [features]
-default = ["robot_conversion", "sitemap_conversion"]
+default = []
 robot_conversion = ["robotparser", "_conversion_any"]
 sitemap_conversion = ["sitemap", "_conversion_any"]
 _conversion_any = [] ##Internal use only

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ try_from = "0.2.2"
 version = "^0.10.1"
 optional = true
 
-[dependencies.sitemaps]
+[dependencies.sitemap]
 version = "^0.3.0"
 optional = true
 
 [features]
-default = []
+default = ["robot_conversion", "sitemap_conversion"]
 robot_conversion = ["robotparser", "_conversion_any"]
-sitemap_conversion = ["sitemaps", "_conversion_any"]
+sitemap_conversion = ["sitemap", "_conversion_any"]
 _conversion_any = [] ##Internal use only

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,26 @@
 [package]
 name = "base_url"
-version = "0.0.7"
+description = "A Url type which strictly cuts out errors related to parsing and host suitability after creation at the cost of some flexibility"
 authors = ["Brady McDonough <brady.mcd.codes@gmail.com>"]
 repository = "https://github.com/bradymcd/rs-baseurl"
 license = "MIT"
-description = "A Url type which strictly cuts out errors related to parsing and host suitability after creation at the cost of some flexibility"
+version = "0.0.8"
 
 
 [dependencies]
 url = "^1.0.0"
 try_from = "0.2.2"
+
+[dependencies.robotparser]
+version = "^0.10.1"
+optional = true
+
+[dependencies.sitemaps]
+version = "^0.3.0"
+optional = true
+
+[features]
+default = []
+robot_conversion = ["robotparser", "_conversion_any"]
+sitemap_conversion = ["sitemaps", "_conversion_any"]
+_conversion_any = [] ##Internal use only

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ creation. As such, a BaseUrl never fails when doing things like calling ```set_p
 
 In any Rust project managed by Cargo add the following to your Cargo.toml ```[dependencies]``` section:
 ```
-base_url="0.0.7"
+base_url="0.0.8"
 ```
 The package exposes base_url which defines the BaseUrl structure at it's root and also re-exports the 
-rust-url crate
+content of the rust-url crate
 ```rust
 extern crate base_url;
 use base_url::BaseUrl;
@@ -24,7 +24,7 @@ the traits found in the [try_from](https://crates.io/crates/try_from) crate.
 
 ## What's Missing?
 
-This is at version 0.0.7 for a reason, there are things to be added before I'm comfortable claiming 
+This is at version 0.0.8 for a reason, there are things to be added before I'm comfortable claiming 
 this library is at a proper first version.  
 Tests should be added, even though this is mostly just a thin wrapper over the Url type proving
 that CannotBeBase errors are truly gone when using the library is something which should be done  

--- a/README.md
+++ b/README.md
@@ -30,7 +30,4 @@ Tests should be added, even though this is mostly just a thin wrapper over the U
 that CannotBeBase errors are truly gone when using the library is something which should be done  
 Finally there are some functions which are still missing, anything which requires me to reimplement the ```parse()```
 function isn't being touched until I really need to, notably ```join()``` isn't available yet.  
-Some of the nominclature also needs to be changed to better reflect what the two Error types are in
-reference to, specifically the UrlError type is going to change since we're re-exporting Url and it
-has nothing to do with that crate.
 

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -1,0 +1,52 @@
+
+use BaseUrl;
+use url::Url;
+
+#[cfg( feature = "robot_conversion" )]
+extern crate robotparser;
+use self::robotparser::RobotFileParser;
+
+#[cfg( feature = "sitemap_conversion" )]
+extern crate sitemap;
+use self::sitemap::structs::{Location, SiteMapEntry, UrlEntry, LastMod, ChangeFreq, Priority};
+
+#[cfg( feature = "robot_conversion" )]
+impl<'a> From< BaseUrl > for RobotFileParser<'a> {
+    /// Conversion into a RobotFileParser from the BaseUrl type
+    fn from( url:BaseUrl ) -> RobotFileParser<'a> {
+        RobotFileParser::<'a>::new( Url::from( url ) )
+    }
+}
+
+
+#[cfg( feature = "sitemap_conversion" )]
+impl From<BaseUrl> for Location {
+    /// Wraps a ```BaseUrl``` into a ```Location```, one of the building blocks of the sitemap crate
+    fn from( url:BaseUrl ) -> Location {
+        Location::from( Url::from( url ) )
+    }
+}
+
+#[cfg( feature = "sitemap_conversion" )]
+impl From< BaseUrl> for SiteMapEntry {
+    /// Conversion into a ```SiteMapEntry``` for a ```BaseUrl```
+    fn from( url:BaseUrl ) -> SiteMapEntry {
+        SiteMapEntry{
+            loc: Location::from( url ),
+            lastmod: LastMod::None,
+        }
+    }
+}
+
+#[cfg( feature = "sitemap_conversion" )]
+impl From< BaseUrl > for UrlEntry {
+    /// Conversion into a ```UrlEntry``` for a ```BaseUrl```
+    fn from( url:BaseUrl ) -> UrlEntry {
+        UrlEntry {
+            loc: Location::from( url ),
+            lastmod: LastMod::None,
+            changefreq: ChangeFreq::None,
+            priority: Priority::None,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,6 @@ use try_from::TryFrom;
 pub use url::{ Host };
 
 use std::str::Split;
-use std::convert::Into;
 use std::net::IpAddr;
 use std::fmt::{Formatter, Display, Result as FormatResult};
 


### PR DESCRIPTION
2 potentially breaking changes:
The Into<Url> for BaseUrl trait was giving me trouble, it is now From<BaseUrl> for Url.
The error type is now called BaseUrlError to better reflect that it doesn't necessarily have anything to do with the rust-url crate